### PR TITLE
less verbose custom DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ open-source library utilizing  modern C++11/14  features and latest Boost.
 
 What makes us different from other open-source RTB projects we have seen?
 
-Our stack is fairly small and 
-easy to integrate with [your cmake project](https://github.com/vanilla-rtb/rapid-bidder) 
-, completely decoupled by C++ templates and has minimum dependency on outside vendors.
+Our stack is fairly small and easy to integrate with any cmake project. 
+As a model project please see [https://github.com/vanilla-rtb/rapid-bidder](https://github.com/vanilla-rtb/rapid-bidder)
 
+vanilla-rtb stack is completely decoupled by C++ templates and has minimum dependency on outside vendors.
 
 [vanilla-rtb ecosystem](../../wiki)
 

--- a/rtb/DSL/generic_dsl.hpp
+++ b/rtb/DSL/generic_dsl.hpp
@@ -25,13 +25,13 @@
 namespace DSL {
     using namespace jsonv;
 
-    template<typename T=std::string , typename Mapper = DSL::dsl_mapper<T>, unsigned int Size=128>
-    class GenericDSL : public Mapper  {
+    template<typename T=std::string , template<class> class Mapper = DSL::dsl_mapper, unsigned int Size=128>
+    class GenericDSL : public Mapper<T>  {
             
     public:
-        using deserialized_type = typename Mapper::deserialized_type;
-        using serialized_type = typename Mapper::serialized_type;
-        using parse_error_type = typename Mapper::parse_error_type;
+        using deserialized_type = typename Mapper<T>::deserialized_type;
+        using serialized_type = typename Mapper<T>::serialized_type;
+        using parse_error_type = typename Mapper<T>::parse_error_type;
 
         GenericDSL() {
             request_fmt_  = this->build_request();


### PR DESCRIPTION
It allows to declare 
using DSLT = DSL::GenericDSL<std::string_view, custom_mapper>;
instead of
using DSLT = DSL::GenericDSL<string_view, custom_mapper<string_view>>;
or even 
using DSLT = DSL::GenericDSL<custom_mapper<string_view>>;
The latter is still consideration for future .
